### PR TITLE
added exclusion for file that need no pipeline to work properly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: Relievely Pipeline
 on:
   push:
-    - "!**.txt"
-    - "!**.md"
+    paths:
+      - "!**.txt"
+      - "!**.md"
 jobs:
   Test-Ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should stop the pipeline from running when we only change files that are here for documentation